### PR TITLE
Add support for custom trait bounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ The separator given to `#( Tuple::something() )SEPARATOR*` can be chosen from `,
 By adding the `#[tuple_types_no_default_trait_bound]` above the impl block, the macro will not add the
 automatic bound to the implemented trait for each tuple type.
 
+The trait bound can be customized using `#[tuple_types_custom_trait_bound(NewBound)]`.
+The new bound will be used instead of the impleted trait for each tuple type.
+Currently advanced bounds, e.g. Trait + Clone, are unsupported.
+
 ## Limitations
 
 The macro does not supports `for_tuples!` calls in a different macro, so stuff like

--- a/README.md
+++ b/README.md
@@ -82,7 +82,6 @@ automatic bound to the implemented trait for each tuple type.
 
 The trait bound can be customized using `#[tuple_types_custom_trait_bound(NewBound)]`.
 The new bound will be used instead of the impleted trait for each tuple type.
-Currently advanced bounds, e.g. Trait + Clone, are unsupported.
 
 ## Limitations
 

--- a/tests/codegen.rs
+++ b/tests/codegen.rs
@@ -525,3 +525,35 @@ fn semi_automatic_tuple_with_custom_trait_bound() {
         }
     }
 }
+
+#[test]
+fn semi_automatic_tuple_with_custom_advanced_trait_bound() {
+    trait Trait {
+        type Arg;
+        type Output;
+
+        fn test(arg: Self::Arg);
+        fn clone_test(&self) -> Self::Output;
+    }
+
+    trait Custom {
+        type NewArg;
+
+        fn new_test(arg: Self::NewArg);
+    }
+
+    #[impl_for_tuples(5)]
+    #[tuple_types_custom_trait_bound(Custom + Clone)]
+    impl Trait for Tuple {
+        for_tuples!( type Arg = ( #( Tuple::NewArg ),* ); );
+        for_tuples!( type Output = ( #( Tuple ),* ); );
+
+        fn test(arg: Self::Arg) {
+            for_tuples!( #( Tuple::new_test(arg.Tuple); )* );
+        }
+
+        fn clone_test(&self) -> Self::Output {
+            for_tuples!( ( #( Tuple.clone() ),* ) );
+        }
+    }
+}

--- a/tests/codegen.rs
+++ b/tests/codegen.rs
@@ -501,3 +501,27 @@ fn test_separators() {
     assert_eq!(<(Impl, Impl, Impl)>::star(), 125);
     assert_eq!(<(Impl, Impl, Impl)>::minus(), -1000);
 }
+
+#[test]
+fn semi_automatic_tuple_with_custom_trait_bound() {
+    trait Trait {
+        type Arg;
+
+        fn test(arg: Self::Arg);
+    }
+
+    trait Custom {
+        type NewArg;
+
+        fn new_test(arg: Self::NewArg);
+    }
+
+    #[impl_for_tuples(5)]
+    #[tuple_types_custom_trait_bound(Custom)]
+    impl Trait for Tuple {
+        for_tuples!( type Arg = ( #( Tuple::NewArg ),* ); );
+        fn test(arg: Self::Arg) {
+            for_tuples!( #( Tuple::new_test(arg.Tuple); )* );
+        }
+    }
+}

--- a/tests/fail/custom_trait_bound_invalid.rs
+++ b/tests/fail/custom_trait_bound_invalid.rs
@@ -1,0 +1,34 @@
+trait Test {
+    type Arg;
+
+    fn test(arg: Self::Arg);
+}
+
+trait Custom {
+    type NewArg;
+
+    fn new_test(arg: Self::NewArg);
+}
+
+#[impl_trait_for_tuples::impl_for_tuples(5)]
+#[tuple_types_custom_trait_bound(Custom + Clone)]
+impl Test for Tuple {
+    for_tuples!( type Arg = ( #( Tuple::NewArg ),* ); );
+    fn test(arg: Self::Arg) {
+        for_tuples!( #( Tuple::new_test(arg.Tuple); )* );
+    }
+}
+
+struct Impl;
+
+impl Custom for Impl {
+    type NewArg = ();
+
+    fn new_test(_arg: Self::NewArg) {}
+}
+
+fn test<T: Test>() {}
+fn main() {
+    test::<(Impl, Impl)>();
+    test::<(Impl, Impl, Impl)>();
+}

--- a/tests/fail/custom_trait_bound_invalid.rs
+++ b/tests/fail/custom_trait_bound_invalid.rs
@@ -11,7 +11,7 @@ trait Custom {
 }
 
 #[impl_trait_for_tuples::impl_for_tuples(5)]
-#[tuple_types_custom_trait_bound(Custom + Clone)]
+#[tuple_types_custom_trait_bound(Custom, Clone)]
 impl Test for Tuple {
     for_tuples!( type Arg = ( #( Tuple::NewArg ),* ); );
     fn test(arg: Self::Arg) {

--- a/tests/fail/custom_trait_bound_invalid.stderr
+++ b/tests/fail/custom_trait_bound_invalid.stderr
@@ -1,0 +1,23 @@
+error: Invalid trait bound, advanced trait bounds are unsupported
+  --> $DIR/custom_trait_bound_invalid.rs:14:41
+   |
+14 | #[tuple_types_custom_trait_bound(Custom + Clone)]
+   |                                         ^
+
+error[E0277]: the trait bound `(Impl, Impl): Test` is not satisfied
+  --> $DIR/custom_trait_bound_invalid.rs:32:12
+   |
+30 | fn test<T: Test>() {}
+   |            ---- required by this bound in `test`
+31 | fn main() {
+32 |     test::<(Impl, Impl)>();
+   |            ^^^^^^^^^^^^ the trait `Test` is not implemented for `(Impl, Impl)`
+
+error[E0277]: the trait bound `(Impl, Impl, Impl): Test` is not satisfied
+  --> $DIR/custom_trait_bound_invalid.rs:33:12
+   |
+30 | fn test<T: Test>() {}
+   |            ---- required by this bound in `test`
+...
+33 |     test::<(Impl, Impl, Impl)>();
+   |            ^^^^^^^^^^^^^^^^^^ the trait `Test` is not implemented for `(Impl, Impl, Impl)`

--- a/tests/fail/custom_trait_bound_invalid.stderr
+++ b/tests/fail/custom_trait_bound_invalid.stderr
@@ -1,8 +1,8 @@
-error: Invalid trait bound, advanced trait bounds are unsupported
-  --> $DIR/custom_trait_bound_invalid.rs:14:41
+error: Invalid trait bound: unexpected token
+  --> $DIR/custom_trait_bound_invalid.rs:14:40
    |
-14 | #[tuple_types_custom_trait_bound(Custom + Clone)]
-   |                                         ^
+14 | #[tuple_types_custom_trait_bound(Custom, Clone)]
+   |                                        ^
 
 error[E0277]: the trait bound `(Impl, Impl): Test` is not satisfied
   --> $DIR/custom_trait_bound_invalid.rs:32:12

--- a/tests/ui/custom_where_clause_not_allowed.stderr
+++ b/tests/ui/custom_where_clause_not_allowed.stderr
@@ -2,4 +2,4 @@ error: Custom where clause not allowed at this position!
  --> $DIR/custom_where_clause_not_allowed.rs:8:9
   |
 8 |         for_tuples!( where #( Tuple: Test ),* )
-  |         ^^^^^^^^^^
+  |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/no_const_value.stderr
+++ b/tests/ui/no_const_value.stderr
@@ -2,4 +2,4 @@ error: Not supported by full-automatic tuple implementation. Use semi-automatic 
  --> $DIR/no_const_value.rs:3:2
   |
 3 |     const Test: u32;
-  |     ^^^^^
+  |     ^^^^^^^^^^^^^^^^

--- a/tests/ui/no_return_value.stderr
+++ b/tests/ui/no_return_value.stderr
@@ -2,4 +2,4 @@ error: Not supported by full-automatic tuple implementation. Use semi-automatic 
  --> $DIR/no_return_value.rs:3:15
   |
 3 |     fn test() -> u32;
-  |               ^^
+  |               ^^^^^^

--- a/tests/ui/no_type_parameter.stderr
+++ b/tests/ui/no_type_parameter.stderr
@@ -2,4 +2,4 @@ error: Not supported by full-automatic tuple implementation. Use semi-automatic 
  --> $DIR/no_type_parameter.rs:3:2
   |
 3 |     type Test;
-  |     ^^^^
+  |     ^^^^^^^^^^


### PR DESCRIPTION
Custom trait bounds can be added with the `#[tuple_types_custom_trait_bound(NewBound)` attribute.
This will use `NewBound` as the type for each Tuple component instead of the Trait being implemented.