### PR TITLE
Allow tuple to be references of type

### DIFF
--- a/src/semi_automatic.rs
+++ b/src/semi_automatic.rs
@@ -708,18 +708,20 @@ impl<'a> Fold for ToTupleImplementation<'a> {
 
 /// Extracts the tuple placeholder ident from the given trait implementation.
 fn extract_tuple_placeholder_ident(trait_impl: &ItemImpl) -> Result<(bool, Ident)> {
-    if let Type::Reference(ref type_ref) = *trait_impl.self_ty {
-        if let Type::Path(ref type_path) = *type_ref.elem {
-            if let Some(ident) = type_path.path.get_ident() {
-                return Ok((true, ident.clone()));
+    match *trait_impl.self_ty {
+        Type::Reference(ref type_ref) => {
+            if let Type::Path(ref type_path) = *type_ref.elem {
+                if let Some(ident) = type_path.path.get_ident() {
+                    return Ok((true, ident.clone()));
+                }
             }
         }
-    }
-
-    if let Type::Path(ref type_path) = *trait_impl.self_ty {
-        if let Some(ident) = type_path.path.get_ident() {
-            return Ok((false, ident.clone()));
+        Type::Path(ref type_path) => {
+            if let Some(ident) = type_path.path.get_ident() {
+                return Ok((false, ident.clone()));
+            }
         }
+        _ => {}
     }
 
     Err(Error::new(

--- a/tests/codegen.rs
+++ b/tests/codegen.rs
@@ -557,3 +557,20 @@ fn semi_automatic_tuple_with_custom_advanced_trait_bound() {
         }
     }
 }
+
+#[test]
+fn semi_automatic_tuple_as_ref() {
+    trait Trait {
+        type Arg;
+
+        fn test(arg: Self::Arg);
+    }
+
+    #[impl_for_tuples(5)]
+    impl Trait for &Tuple {
+        for_tuples!( type Arg = ( #( Tuple::Arg ),* ); );
+        fn test(arg: Self::Arg) {
+            for_tuples!( #( Tuple::test(arg.Tuple); )* )
+        }
+    }
+}


### PR DESCRIPTION
Allows the placeholder `Tuple` identifier to accept a reference which will cause the tuple contents to be references themselves.

E.g:
```rust
#[impl_for_tuples(5)]
impl Trait for &Tuple {
    // ...
}
```
Will expand to:
```rust
impl<TupleElement0: Trait> Trait for (&TupleElement0,) { //... };
impl<TupleElement0: Trait, TupleElement1: Trait> Trait for (&TupleElement0, &TupleElement1, ) { //... };
//etc...
```
